### PR TITLE
fix(editor): refresh ace editor when switching concepts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ rapidfuzz
 matplotlib
 pydantic
 bibtexparser
+streamlit-ace

--- a/templates_latex/miestilo.sty
+++ b/templates_latex/miestilo.sty
@@ -35,6 +35,7 @@
 \RequirePackage{siunitx,gensymb}
 \RequirePackage{xcolor}
 \RequirePackage{hyperref}
+\RequirePackage{dirtree}
 \RequirePackage{listings}
 % --------------------------------------------
 % Definir colores parar el código


### PR DESCRIPTION
# Streamlit ACE Editor Integration & Editor State Fixes

## Summary of Changes

This pull request introduces a major usability and correctness improvement to the Math Knowledge Base editor by integrating a syntax‑highlighted LaTeX editor and fixing critical state‑handling issues when adding and editing concepts.

---

## 1. LaTeX Editor Upgrade

- Replaced the plain `st.text_area` with **`streamlit-ace`** as the main LaTeX editor.
- Enabled:
  - LaTeX syntax highlighting
  - Dark theme (`monokai`)
  - Line numbers (gutter)
  - Adjustable font size and editor height
- This significantly improves usability for long mathematical and technical texts.

---

## 2. Robust Editor State Management (Add Concept)

- Introduced a canonical state variable:
  - `st.session_state["latex_text"]`
- Avoided illegal mutations of widget keys (prevents `StreamlitAPIException`).
- Implemented a **controlled remount mechanism**:
  - `latex_editor_rev` is incremented whenever programmatic insertion occurs.
  - The ACE editor key depends on this revision counter.
- Result: safe updates after snippet insertion without stale UI state.

---

## 3. LaTeX Snippet Insertion Toolbar

Added a structured toolbar to insert LaTeX templates via buttons:

### Mathematical Structures
- Definition, Theorem, Lemma, Proposition, Corollary
- Proof, Example, Remark
- Equation, Align, Matrix, Cases

### Lists & Quotes
- Itemize, Enumerate, Description, Quote

### Symbols & Greek Letters
- Common operators and symbols
- Full Greek alphabet (lowercase & uppercase)

### Insertion Flow
- Button prepares a snippet
- UI displays **“Ready to insert”**
- Explicit **Insert at Cursor** action
- State cleanup after insertion

---

## 4. Advanced Snippets Added

### Code Listing Button
Inserts a LaTeX `lstlisting` environment:

```latex
\begin{lstlisting}[language=ValorLanguage, caption=NameForCaption]
# Comment
code
\end{lstlisting}
```

### Directory Tree Button
Inserts a `\dirtree{}` structure:

```latex
\dirtree{
.1 root.
.2 folder.
.3 file.
}
```

Useful for technical notes, documentation, and code‑heavy concepts.

---

## 5. Critical Fix: Edit Concept Editor Refresh

### Problem
When switching between concepts in **Edit Concept**, the editor did not refresh and displayed stale LaTeX content — a serious data‑integrity risk.

### Solution
- Introduced independent edit state:
  - `edit_latex_text`
  - `edit_latex_editor_rev`
- The ACE editor key now depends on:
  - Concept ID
  - Source
  - Revision counter

```text
edit_latex_editor__<id>@<source>__<rev>
```

### Result
- The editor **always remounts** when a different concept is selected.
- Eliminates accidental editing of the wrong concept.

---

## 6. Snippet Insertion in Edit Concept

- Replicated the snippet insertion system for Edit Concept:
  - `edit_latex_insert`
  - `edit_insert_latex`
- State is fully isolated from Add Concept to avoid collisions.
- Enables safe enrichment of existing concepts.

---

## 7. Files Modified

- `editor_streamlit.py`
  - ACE editor integration
  - State handling fixes
  - Snippet toolbars
  - Edit Concept refresh logic
- `requirements.txt`
  - Added `streamlit-ace`
- `miestilo.sty`
  - LaTeX style updates for `lstlisting` and `dirtree` compatibility

---

## 8. Functional Impact

- Editing is now **safe, predictable, and explicit**.
- Writing mathematical and technical content is **faster and less error‑prone**.
- The editor architecture is now ready for future extensions:
  - True cursor‑position insertion
  - Custom snippet presets
  - Live LaTeX/PDF preview

---

## Recommended Merge Strategy

- ✅ Squash merge (logical single feature)
- Conventional commit suggestion:
  ```
  feat(editor): integrate ACE LaTeX editor and fix concept switching
  ```