### PR TITLE
feat: cognitive relation tutor and semantic validation for knowledge graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,44 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to Semantic Versioning.
+
+---
+
+## [Unreleased] — 2026-01-07
+
+### Added
+- Cognitive **Relation Tutor** for semantic relations between concepts.
+- Verification **checklists** per relation type (`equivalente`, `implica`, `requiere_concepto`, `contradice`, `contra_ejemplo`).
+- Tri-state evaluation (`Sí / No / No sé`) for essential and optional criteria.
+- **Quality feedback** with semantic warnings based on checklist completion.
+- **Strict mode** option to block saving relations unless essential criteria are satisfied.
+- Contextual **visual preview** of relations with configurable hop depth.
+- Mini **subgraph preview** to validate local consistency and detect cycles early.
+- Toggleable display of **Titles / IDs / Both** for concepts and relations.
+- Export of relation preview and subgraph as **JSON**.
+- Downloadable **HTML map** for visual previews.
+
+### Improved
+- Relation assignment workflow is now educational and self-validating.
+- Graph preview readability by replacing internal IDs with human-readable titles.
+- Early detection of questionable or underspecified relations before persistence.
+- UX consistency between preview graphs and full visualization graphs.
+
+### Technical
+- Centralized relation semantics via `RELATION_CHECKLIST`.
+- Session-scoped checklist state (non-persistent by design).
+- Modular preview graph generation aligned with main visualization engine.
+- Updated Makefile targets for development workflow consistency.
+
+### Design Notes
+- Checklist responses are intentionally **not persisted** to the database.
+- Relation tutor acts as a **cognitive scaffold**, not as stored metadata.
+- Separation preserved between conceptual validation and canonical data.
+
+---
 
 ## [Unreleased] — 2026-01-07
 

--- a/Makefile
+++ b/Makefile
@@ -6,20 +6,20 @@ SHELL := /bin/bash
 # -----------------------
 
 start:
-	. mathdbmongo/bin/activate && make mongo
+	@$(MAKE) mongo
 
 mongo:
-	sudo systemctl start mongod
-	sudo systemctl status mongod
+	@sudo systemctl start mongod
+	@sudo systemctl --no-pager status mongod || true
 
 stop:
-	. mathdbmongo/bin/activate && sudo systemctl stop mongod && echo "✅ MongoDB detenido."
+	@. mathdbmongo/bin/activate && sudo systemctl stop mongod && echo "✅ MongoDB detenido."
 
 restart:
-	. mathdbmongo/bin/activate && sudo systemctl restart mongod && make status
+	@. mathdbmongo/bin/activate && sudo systemctl restart mongod && make status
 
 status:
-	sudo systemctl status mongod
+	@sudo systemctl status mongod
 
 # -----------------------
 # 🚀 Aplicación Principal

--- a/editor/interactive_graph.py
+++ b/editor/interactive_graph.py
@@ -59,7 +59,13 @@ class InteractiveGraphManager:
             "contra_ejemplo": "dotted"
         }
     
-    def get_graph_data(self, selected_concept_id: Optional[str] = None, 
+    def _apply_style(self, net, profile: str = "full"):
+        if profile == "full":
+            net.set_options(self.FULL_OPTIONS_JSON)
+        else:
+            net.set_options(self.FULL_OPTIONS_JSON)  # mismo estilo, solo cambia height si quieres
+
+    def get_graph_data(self, selected_concept_id: Optional[str] = None,
                       selected_concept_source: Optional[str] = None,
                       filter_sources: Optional[List[str]] = None,
                       filter_types: Optional[List[str]] = None,


### PR DESCRIPTION
## Summary

This PR introduces a cognitive layer for assigning and validating semantic relations between concepts in the Math Knowledge Base.

Relations are no longer treated as simple edges, but as **claims that require justification**, supported by guided verification and visual context.

---

## Key Features

- **Relation Tutor** with explicit definitions per relation type.
- Verification **checklists** (essential + optional) for:
  - equivalente
  - implica
  - requiere_concepto
  - contradice
  - contra_ejemplo
- Tri-state evaluation (`Sí / No / No sé`) with semantic quality feedback.
- Optional **strict mode** to block saving relations when essential criteria are not met.
- Contextual **graph preview** with configurable hop depth.
- Mini subgraph visualization to detect cycles and inconsistencies early.
- Toggle between **Titles / IDs / Both** for nodes and relations.
- Export of preview graphs and relation context as **JSON**.
- Downloadable **HTML map** for visual inspection.

---

## Design Decisions

- Checklist responses are **not persisted** in the database by design.
- The tutor acts as a **cognitive scaffold**, not as canonical metadata.
- Canonical relations remain clean, minimal, and framework-agnostic.
- Validation is performed **before persistence**, not after.

---

## Motivation

This change aims to make relation assignment:
- More educational
- More rigorous
- Less error-prone
- Better aligned with mathematical reasoning practices

---

## Scope

- No breaking changes to existing data.
- Existing relations remain valid.
- All changes are additive and backward-compatible.

---

## Related

- Changelog: `0.2.0 – 2026-01-08`
