### PR TITLE
feat(dashboard): add relations Sankey MVP (plotly) + source filter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ matplotlib
 pydantic
 bibtexparser
 streamlit-ace
+plotly>=5.0


### PR DESCRIPTION
## Summary
Adds an MVP Sankey chart to visualize concept relations as a flow:
Source → RelationType → Source.

Includes a source filter toggle (All sources vs selected).

## Why
The existing graph view is useful but visually dense. Sankey provides a compact,
aggregate view that highlights the strongest relation patterns and reveals how
knowledge moves across sources.

## Changes
- Dashboard: new “Relations Flow (Sankey)” section (Plotly)
- Adds source-based filtering aligned with Quick Stats source selection
- Adds Plotly dependency

## How to test
1. `make run`
2. Go to **Dashboard**
3. Toggle **All sources**
4. Verify the Sankey updates (and does not crash with empty relations)

## Notes / MVP Scope
This is an aggregate visualization (not per-concept navigation yet).
Future upgrades: click-to-filter by source, relation type, or drill-down to nodes.
